### PR TITLE
Added compatibility with passing S3 url for the template instead of a local file

### DIFF
--- a/lib/cloudformer/stack.rb
+++ b/lib/cloudformer/stack.rb
@@ -19,7 +19,7 @@ class Stack
     return stack.exists?
   end
 
-  def apply(template_file, parameters, disable_rollback=false, capabilities=[])
+  def apply(template_file, parameters, disable_rollback=false, capabilities=[], notify=[])
     if ( template_file =~ /^https:\/\/s3\S+\.amazonaws\.com\/(.*)/ )
       template = template_file
     else
@@ -34,7 +34,7 @@ class Stack
     if deployed
       pending_operations = update(template, parameters, capabilities)
     else
-      pending_operations = create(template, parameters, disable_rollback, capabilities)
+      pending_operations = create(template, parameters, disable_rollback, capabilities, notify)
     end
     wait_until_end if pending_operations
     return deploy_succeded?
@@ -151,9 +151,9 @@ class Stack
     return false
   end
 
-  def create(template, parameters, disable_rollback, capabilities)
+  def create(template, parameters, disable_rollback, capabilities, notify)
     puts "Initializing stack creation..."
-    @cf.stacks.create(name, template, :parameters => parameters, :disable_rollback => disable_rollback, :capabilities => capabilities)
+    @cf.stacks.create(name, template, :parameters => parameters, :disable_rollback => disable_rollback, :capabilities => capabilities, :notify => notify)
     sleep 10
     return true
   rescue ::AWS::CloudFormation::Errors::ValidationError => e
@@ -178,3 +178,4 @@ class Stack
     end
   end
 end
+

--- a/lib/cloudformer/tasks.rb
+++ b/lib/cloudformer/tasks.rb
@@ -13,7 +13,7 @@ module Cloudformer
      end
    end
 
-   attr_accessor :template, :parameters, :disable_rollback, :retry_delete, :capabilities
+   attr_accessor :template, :parameters, :disable_rollback, :retry_delete, :capabilities, :notify
 
    private
    def define_tasks
@@ -35,7 +35,7 @@ module Cloudformer
         if retry_delete
           @stack.delete
         end
-       exit 1 unless @stack.apply(template, parameters, disable_rollback, capabilities)
+       exit 1 unless @stack.apply(template, parameters, disable_rollback, capabilities, notify)
      end
    end
 

--- a/lib/cloudformer/version.rb
+++ b/lib/cloudformer/version.rb
@@ -1,3 +1,3 @@
 module Cloudformer
-  VERSION = "0.0.11.1"
+  VERSION = "0.0.11.2"
 end


### PR DESCRIPTION
Hopefully others will find this modification useful when dealing with template files larger than the file size limit amazon imposes on uploading the template contents as a json string.
