### PR TITLE
Exit with code 2 if CloudFormation tells us no updates are needed

### DIFF
--- a/lib/cloudformer/stack.rb
+++ b/lib/cloudformer/stack.rb
@@ -28,7 +28,7 @@ class Stack
     validation = validate(template)
     unless validation["valid"]
       puts "Unable to update - #{validation["response"][:code]} - #{validation["response"][:message]}"
-      return false
+      return :Failed
     end
     pending_operations = false
     begin
@@ -39,10 +39,10 @@ class Stack
       end
     rescue ::AWS::CloudFormation::Errors::ValidationError => e
       puts e.message
-      return false
+      return (if e.message == "No updates are to be performed." then :NoUpdates else :Failed end)
     end
     wait_until_end if pending_operations
-    return deploy_succeded?
+    return (if deploy_succeded? then :Succeeded else :Failed end)
   end
 
   def deploy_succeded?

--- a/lib/cloudformer/tasks.rb
+++ b/lib/cloudformer/tasks.rb
@@ -35,7 +35,9 @@ module Cloudformer
         if retry_delete
           @stack.delete
         end
-       exit 1 unless @stack.apply(template, parameters, disable_rollback, capabilities, notify)
+        result = @stack.apply(template, parameters, disable_rollback, capabilities, notify)
+        if result == :Failed then exit 1 end
+        if result == :NoUpdates then exit 2 end
      end
    end
 


### PR DESCRIPTION
I would like to be able to distinguish between the case where 'apply' fails due to an actual problem with the template, and the case where it fails because the template hasn't changed.
