### PR TITLE
Using correct aws sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Or install it yourself as:
 
 Cloudformer depends on the aws-sdk gem to query AWS API. You will need to export AWS configuration to environment variables to your .bashrc/.bash_profile or your build server:
 
-    export AWS_ACCESS_KEY=your access key
+    export AWS_ACCESS_KEY_ID=your access key
     export AWS_REGION=ap-southeast-2
     export AWS_SECRET_ACCESS_KEY=your secret access key
 

--- a/cloudformer.gemspec
+++ b/cloudformer.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec"
   spec.add_dependency "rake"
-  spec.add_dependency "aws-sdk", '~> 1.0'
+  spec.add_dependency "aws-sdk-v1"
   spec.add_dependency "httparty"
 end

--- a/lib/cloudformer/stack.rb
+++ b/lib/cloudformer/stack.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'httparty'
 
 class Stack


### PR DESCRIPTION
There appears to be an issue with using the aws-sdk gem  On systems where that gem is version 2.x, the require of 'aws-sdk' will use version 2.x. and the error about AWS vs Aws namespace will occur.

To fix, you need to use the gem 'aws-sdk-v1' and this will ensure that gem can live alongside a version 2.x of 'aws-sdk'.

Please double check this, as my knowledge of ruby is limited.