### PR TITLE
Removed ^M's and removed duplicate definition of the validate method

### DIFF
--- a/lib/cloudformer/stack.rb
+++ b/lib/cloudformer/stack.rb
@@ -146,14 +146,6 @@ class Stack
     puts "="*cols
   end
 
-  def validate(template)
-    response = @cf.validate_template(template)
-    return {
-      "valid" => response[:code].nil?,
-      "response" => response
-    }
-  end
-
   def update(template, parameters, capabilities)
     stack.update({
       :template => template,


### PR DESCRIPTION
The validate method was defined below the "private" line so "rake validate" would never work, as it would complain that the method is private.