### PR TITLE
Explicitly depend on aws-sdk-v1

### DIFF
--- a/cloudformer.gemspec
+++ b/cloudformer.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec"
   spec.add_dependency "rake"
-  spec.add_dependency "aws-sdk", '~> 1.0'
+  spec.add_dependency "aws-sdk-v1", '~> 1.0'
   spec.add_dependency "httparty"
 end

--- a/lib/cloudformer/stack.rb
+++ b/lib/cloudformer/stack.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'httparty'
 
 class Stack
@@ -179,4 +179,3 @@ class Stack
     end
   end
 end
-


### PR DESCRIPTION
When cloudformer is pulled into a project that uses aws-sdk version 2, bundler reports a version conflict because cloudformer requires version 1.x. To get around this problem and allow both versions to co-exist, AWS have published v1 under a different gem name: [aws-sdk-v1](https://rubygems.org/gems/aws-sdk-v1).

This PR updates the cloudformer gem dependencies to explicitly depend on the "aws-sdk-v1" gem, which allows it to be used in projects that use v2.

Related to #16.
